### PR TITLE
Fixup issue with NAT ipv4 address

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -19,6 +19,9 @@
    - nagios-plugins-procs
    - nagios-plugins-load
    - nagios-plugins-disk
+   - nagios-plugins-http
+   - nagios-plugins-ssh
+   - nagios-plugins-ping
 
 - name: Install ntp
   yum: name=ntp state=present

--- a/roles/nagios/templates/dbservers.cfg.j2
+++ b/roles/nagios/templates/dbservers.cfg.j2
@@ -10,7 +10,7 @@ define hostgroup {
                 use                     linux-server
                 host_name               {{ host }}
                 alias                   {{ host }}
-                address                 {{ hostvars[host].ansible_default_ipv4.address }}
+                address                 {{ hostvars[host].ansible_ssh_host }}
                 hostgroups              dbservers 
                 }
 {% endfor %}

--- a/roles/nagios/templates/webservers.cfg.j2
+++ b/roles/nagios/templates/webservers.cfg.j2
@@ -10,7 +10,7 @@ define hostgroup {
 	use                     linux-server
 	host_name               {{ host }} 
 	alias                   {{ host }}
-	address                 {{ hostvars[host].ansible_default_ipv4.address }}
+	address                 {{ hostvars[host].ansible_ssh_host }}
 	hostgroups 		webservers
   }    
 {% endfor %}


### PR DESCRIPTION
David, not sure if you've run into this with demos before, but I noticed the default IPv4 address leverages the first (NAT) interface configured on the vagrant VM -- referencing the ansible_ssh_host var to force use of the host-only NIC fixed up Nagios monitoring issues I experienced.